### PR TITLE
Time and freq as floats, not objects

### DIFF
--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -315,3 +315,7 @@ def test_sources_equal():
     src1 = create_zenith_source(time, 'src')
     src2 = create_zenith_source(time, 'src')
     nt.assert_equal(src1, src2)
+
+def test_mock_catalog():
+    time = Time('2018-03-01 00:00:00', scale='utc')
+    cat = pyuvsim.create_mock_catalog(time, arrangement='asym1')

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -179,7 +179,7 @@ def test_file_to_tasks():
 
     beam_list = [beam]
 
-    uvtask_list = pyuvsim.uvfile_to_task_list(hera_uv, sources, beam_list)
+    uvtask_list = pyuvsim.uvdata_to_task_list(hera_uv, sources, beam_list)
 
     tel_loc = EarthLocation.from_geocentric(*hera_uv.telescope_location, unit='m')
     beam = UVBeam()
@@ -216,7 +216,7 @@ def test_file_to_tasks():
     for idx, antenna1 in enumerate(antennas1):
         antenna2 = antennas2[idx]
         baseline = pyuvsim.Baseline(antenna1, antenna2)
-        task = pyuvsim.UVTask(sources[0], time, hera_uv.freq_array[0, 0] * units.Hz, baseline, telescope)
+        task = pyuvsim.UVTask(sources[0], time.jd, hera_uv.freq_array[0, 0], baseline, telescope)
         task.uvdata_index = (idx, 0, 0)
         expected_task_list.append(task)
 
@@ -242,8 +242,11 @@ def test_uvdata_init():
 
     beam_list = [beam]
 
-    uvtask_list = pyuvsim.uvfile_to_task_list(hera_uv, sources, beam_list)
-
+    uvtask_list = pyuvsim.uvdata_to_task_list(hera_uv, sources, beam_list)
+    for task in uvtask_list:
+        task.time = Time(task.time, format='jd')
+        task.freq = task.freq * units.Hz
+        
     uvdata_out = pyuvsim.initialize_uvdata(uvtask_list)
 
     hera_uv.data_array = np.zeros_like(hera_uv.data_array, dtype=np.complex)
@@ -279,7 +282,7 @@ def test_gather():
 
     beam_list = [beam]
 
-    uvtask_list = pyuvsim.uvfile_to_task_list(hera_uv, sources, beam_list)
+    uvtask_list = pyuvsim.uvdata_to_task_list(hera_uv, sources, beam_list)
 
     for task in uvtask_list:
         engine = pyuvsim.UVEngine(task)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -539,12 +539,25 @@ def serial_gather(uvtask_list):
 def create_mock_catalog(time,arrangement='zenith',**kwargs):
     """
         Create mock catalog with test sources at zenith.
+
         arrangment = Choose test point source pattern (default = 1 source at zenith)
+        Nsrcs = Number of sources to put at zenith (ignored for other source arrangements)
+        Accepted arrangements:
+            'triangle' = Three point sources forming a triangle around the zenith
+            'asym1'    = An asymmetric cross
+            'zenith'   = Some number of sources placed at the zenith.
 
     """
+ 
     array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
                                    height=1073.)
     freq = (150e6 * units.Hz)
+ 
+    if arrangement == 'triangle':
+        Nsrcs = 3
+        alts = [88.,88,88.]
+        azs = [0., 120, 240.]
+        fluxes = [1.0,1.0,1.0]
 
     if arrangement == 'asym1':
         Nsrcs = 4

--- a/scripts/run_pyuvsim.py
+++ b/scripts/run_pyuvsim.py
@@ -39,7 +39,7 @@ for filename in args.file_in:
                        model_version='1.0')
 
     beam_list = [beam]
-    uvdata_out = pyuvsim.uvsim.run_uvsim(input_uv, beam_list=beam_list, Nsrcs=args.Nsrcs)
+    uvdata_out = pyuvsim.uvsim.run_uvsim(input_uv, beam_list=beam_list,mock_arrangement='asym1', Nsrcs=args.Nsrcs)
     if rank == 0:
         outfile = os.path.join(args.outdir, 'sim_' + os.path.basename(filename))
         uvdata_out.write_uvfits(outfile, force_phase=True, spoof_nonessential=True)


### PR DESCRIPTION
Create tasks with time and freq as floats to ease splitting during uvtask generation step, then convert to astropy Time and Quantity objects on the MPI processes (in UVEngine).

This speeds up the uvtask_array generation, but we'll need to ensure that any setup function keeps the correct units (julian date and Hz, respectively) from the beginning. Either that, or we have to pass along the units as well to the separate processes.

Also some changes to the mock catalog generator.